### PR TITLE
Use Processor::process_instruction and turn on no-entrypoint

### DIFF
--- a/program/fuzz/Cargo.toml
+++ b/program/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3"
 solana-program-test = "1.5.0"
 spl-token = {version = "3.0.1", features = ["no-entrypoint"]}
 spl-associated-token-account = {version = "1.0.2", features = ["no-entrypoint"]}
-token-vesting =  { version = "0.1.0", path="..", features=["fuzz"] }
+token-vesting =  { version = "0.1.0", path="..", features=["fuzz", "no-entrypoint"] }
 tokio = { version = "0.3", features = ["macros"]}
 
 [[bin]]


### PR DESCRIPTION
The main change is to go from using `process_instruction` from the entrypoint to its `Processor` variant, and then pulling in the vesting program dependency with the `no-entrypoint` feature turned on.

I still get the issue of `/tmp` getting filled up with gigabytes of garbage within minute, but that'll likely be a change on the ProgramTest side to suppress all logging in the fuzz environment.