### PR TITLE
Update solana dependencies, use new program-test

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -17,21 +17,20 @@ test-bpf = []
 fuzz = ["arbitrary", "honggfuzz"]
 
 [dependencies]
-solana-program = "1.5.0"
 thiserror = "1.0.23"
 num-traits = "0.2"
 num-derive = "0.3"
 arrayref = "0.3.6"
-spl-token = {version = "3.0.1", features = ["no-entrypoint"]}
-spl-associated-token-account = {version = "1.0.2", features = ["no-entrypoint"]}
+solana-program = "1.5.6"
+spl-token = { version = "3.0.1", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "1.0.2", features = ["no-entrypoint"] }
 arbitrary = { version = "0.4", features = ["derive"], optional = true }
 honggfuzz = { version = "0.5", optional = true }
 
 [dev-dependencies]
-solana-sdk = "1.5.0"
-solana-program-test = "1.5.0"
+solana-sdk = "1.5.6"
+solana-program-test = "1.5.6"
 tokio = { version = "0.3", features = ["macros"]}
 
 [lib]
 crate-type = ["cdylib", "lib"]
-

--- a/program/fuzz/Cargo.toml
+++ b/program/fuzz/Cargo.toml
@@ -8,12 +8,11 @@ edition = "2018"
 [dependencies]
 honggfuzz = { version = "0.5" }
 arbitrary = { version = "0.4", features = ["derive"] }
-solana-program = "1.5.0"
-solana-sdk = "1.5.0"
-futures = "0.3"
-solana-program-test = "1.5.0"
-spl-token = {version = "3.0.1", features = ["no-entrypoint"]}
-spl-associated-token-account = {version = "1.0.2", features = ["no-entrypoint"]}
+solana-program = "1.5.6"
+solana-sdk = "1.5.6"
+solana-program-test = "1.5.6"
+spl-token = { version = "3.0.1", features = ["no-entrypoint"] }
+spl-associated-token-account = { version = "1.0.2", features = ["no-entrypoint"] }
 token-vesting =  { version = "0.1.0", path="..", features=["fuzz", "no-entrypoint"] }
 tokio = { version = "0.3", features = ["macros"]}
 


### PR DESCRIPTION
Program-test was fixed in https://github.com/solana-labs/solana/pull/14908 to avoid blowing up `/tmp`.  I tested the change locally against the fuzzing, and after a few hours, only an error in the fuzzing code was found, which is also fixed in this PR.  I don't know when 1.5.6 will be released just yet, but it should be within a week.  When it happens, I'll change the PR out of draft, so then it'll be ready to be merged in.

Let me know if you have any questions!